### PR TITLE
Fix about IPV4 address problem in Zig 0.16.0

### DIFF
--- a/src/linux/network.zig
+++ b/src/linux/network.zig
@@ -26,15 +26,14 @@ pub fn getNetInfo(gpa: std.mem.Allocator) !std.array_list.Managed(NetInfo) {
 
             if (sockaddr_ptr.sa_family != c.AF_INET) continue;
 
-            var addr_in = @as(*const c.sockaddr_in, @ptrCast(@alignCast(sockaddr_ptr)));
-            var ip_buf: [c.INET_ADDRSTRLEN]u8 = undefined;
-            const ip_str = c.inet_ntop(c.AF_INET, &addr_in.sin_addr, &ip_buf, c.INET_ADDRSTRLEN);
-            if (ip_str) |ip| {
-                try net_info_list.append(NetInfo{
-                    .interface_name = try gpa.dupe(u8, std.mem.span(ifa.ifa_name)),
-                    .ipv4_addr = try gpa.dupe(u8, std.mem.span(ip)),
-                });
-            }
+            const addr_in = @as(*const c.sockaddr_in, @ptrCast(@alignCast(sockaddr_ptr)));
+            const bytes = std.mem.asBytes(&addr_in.sin_addr.s_addr);
+            const ipv4_addr = try std.fmt.allocPrint(gpa, "{d}.{d}.{d}.{d}", .{ bytes[0], bytes[1], bytes[2], bytes[3] });
+
+            try net_info_list.append(NetInfo{
+                .interface_name = try gpa.dupe(u8, std.mem.span(ifa.ifa_name)),
+                .ipv4_addr = ipv4_addr,
+            });
         }
     }
 


### PR DESCRIPTION
## Brief introduction

`zigfetch` 0.27.0 no longer builds on Linux with Zig 0.16.0 because the current network code calls `c.inet_ntop()` from the translated C bindings. On glibc systems, Zig 0.16.0 translates the fortified `inet_ntop` wrapper into code that passes a `bool` to `__builtin.object_size`, which causes compilation to fail.

This patch avoids the broken libc path entirely by formatting IPv4 addresses directly from `sin_addr.s_addr` in Zig. The behavior is unchanged for users, but the build now succeeds cleanly on current Arch tooling.

### Why this change
- Fixes the `expected type 'c_int', found 'bool'` build error on Zig 0.16.0
- Removes dependence on the problematic glibc fortify wrapper for `inet_ntop`
- Keeps the fix small and Linux-only

### Validation
- `zig build -Doptimize=ReleaseSafe` passes with Zig 0.16.0
- The resulting binary still reports IPv4 addresses correctly
